### PR TITLE
one app. fix #16 fix #15

### DIFF
--- a/python/env/manualclassify/classify/local_settings.py.template
+++ b/python/env/manualclassify/classify/local_settings.py.template
@@ -1,0 +1,24 @@
+SECRET_KEY = 'a908oi34yuh5naerdf0v98y3uh4jtergzdf9o87hunjae4gr'
+
+ALLOWED_HOSTS = ['localhost']
+
+DEFAULT_DATABASE = {
+    'ENGINE': 'django.db.backends.postgresql',
+    'NAME': 'my_database',
+    'USER': 'my_database_user',
+    'PASSWORD': 'some_password',
+    'HOST': 'localhost',
+    'PORT': ''
+}
+
+# uncomment below for LDAP authentication
+
+# LDAP_HOST = 'my_ldap_host.foo.bar'
+# LDAP_PORT = 636
+# LDAP_SSL = True
+
+# LDAP_SEARCH_DN = 'a_distinguished_name'
+# LDAP_SEARCH_PW = 'some_password'
+# LDAP_SEARCH_BASE = 'a_distinguished_name'
+
+# AUTHENTICATION_BACKENDS = ( 'classify.ldap_auth.LdapBackend', )

--- a/python/env/manualclassify/classify/settings.py
+++ b/python/env/manualclassify/classify/settings.py
@@ -7,25 +7,16 @@ https://docs.djangoproject.com/en/1.7/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
+from .local_settings import *
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'so*=!p8qwd%ygh3+*u@tu90ls7&rzy&k=lz$#bl7#m4d*&^q$2'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
 TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = ['localhost']
-
 
 # Application definition
 
@@ -53,47 +44,29 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'classify.urls'
 
 TEMPLATES = [
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [],
-            'APP_DIRS': True,
-            'OPTIONS': {
-                'context_processors': [
-                                    'django.template.context_processors.debug',
-                                    'django.template.context_processors.request',
-                                    'django.contrib.auth.context_processors.auth',
-                                    'django.contrib.messages.context_processors.messages',
-                                ],
-                        },
-                },
-    ]
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
-WSGI_APPLICATION = 'manualclassify.wsgi.application'
+WSGI_APPLICATION = 'classify.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'django_db',
-        'USER': 'django',
-        'PASSWORD': '********',
-        'HOST': 'localhost',
-        'PORT': ''
-    }
+    'default': DEFAULT_DATABASE
 }
-
-# LDAP authentication
-LDAP_HOST = '*******'
-LDAP_PORT = 636
-LDAP_SSL = True
-
-LDAP_SEARCH_DN = '**************'
-LDAP_SEARCH_PW = '**************'
-LDAP_SEARCH_BASE = '**************'
-
-# AUTHENTICATION_BACKENDS = ( 'classify.ldap_auth.LdapBackend', )
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/
@@ -107,7 +80,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/

--- a/python/env/manualclassify/classify/wsgi.py
+++ b/python/env/manualclassify/classify/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for manualclassify project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "classify.settings")
+
+application = get_wsgi_application()

--- a/python/env/manualclassify/manage.py
+++ b/python/env/manualclassify/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "classify.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
* split settings.py into settings and local settings (all secret information is in local_settings which is .gitignored) and committed settings.py and a local settings template with dummy values for hosts, passwords, etc.

* committed manage.py and wsgi.py configuring them correctly for the classify application

This should alleviate the need to create a django project called manualclassify every time this is installed; instead there's just one app, classify, which is also the django project.