### PR TITLE
CACHE_DIR setting, fixed #25

### DIFF
--- a/python/env/manualclassify/classify/local_settings.py.template
+++ b/python/env/manualclassify/classify/local_settings.py.template
@@ -13,6 +13,8 @@ DEFAULT_DATABASE = {
     'PORT': ''
 }
 
+CACHE_DIR = '/var/www/something/something/cache'
+
 # uncomment below for LDAP authentication
 
 # LDAP_HOST = 'my_ldap_host.foo.bar'

--- a/python/env/manualclassify/classify/utils.py
+++ b/python/env/manualclassify/classify/utils.py
@@ -7,12 +7,13 @@ from django.contrib.auth.models import User
 import json
 import time
 import logging
+from .settings import CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
-ZIP_CACHE_PATH = 'classify/cache/zips'
-TARGETS_CACHE_PATH = 'classify/cache/targets'
-AUTO_RESULTS_CACHE_PATH = 'classify/cache/class_scores'
+ZIP_CACHE_PATH = os.path.join(CACHE_DIR,'zips')
+TARGETS_CACHE_PATH = os.path.join(CACHE_DIR,'targets')
+AUTO_RESULTS_CACHE_PATH = os.path.join(CACHE_DIR,'class_scores')
 
 if not os.path.exists(ZIP_CACHE_PATH):
     os.makedirs(ZIP_CACHE_PATH, exist_ok=True)


### PR DESCRIPTION
This requires configuring CACHE_DIR in local_settings.py, intended to be the absolute path to a webserver-writable cache directory.